### PR TITLE
🚀  presignedUrl 반환 방식 변경; imageUrl -> (imageUrl + id)

### DIFF
--- a/src/main/java/com/sparta/taptoon/domain/image/controller/ImageController.java
+++ b/src/main/java/com/sparta/taptoon/domain/image/controller/ImageController.java
@@ -1,6 +1,7 @@
 package com.sparta.taptoon.domain.image.controller;
 
-import com.sparta.taptoon.domain.image.dto.PreSignedUrlRequest;
+import com.sparta.taptoon.domain.image.dto.request.PreSignedUrlRequest;
+import com.sparta.taptoon.domain.image.dto.response.PresignedUrlResponse;
 import com.sparta.taptoon.domain.image.service.ImageService;
 import com.sparta.taptoon.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,9 +23,9 @@ public class ImageController {
 
     @Operation(summary = "preSignedUrl 방식 이미지 업로드")
     @PostMapping("/upload")
-    public ResponseEntity<ApiResponse<String>> getPresignedUrl(
+    public ResponseEntity<ApiResponse<PresignedUrlResponse>> getPresignedUrl(
             @Valid @RequestBody PreSignedUrlRequest request) {
-        String presignedUrl = imageService.generatePresignedUrl(request.directory(), request.id(), request.fileName());
+        PresignedUrlResponse presignedUrl = imageService.generatePresignedUrl(request.directory(), request.id(), request.fileName());
         return ApiResponse.success(presignedUrl);
     }
 }

--- a/src/main/java/com/sparta/taptoon/domain/image/dto/request/PreSignedUrlRequest.java
+++ b/src/main/java/com/sparta/taptoon/domain/image/dto/request/PreSignedUrlRequest.java
@@ -1,10 +1,12 @@
-package com.sparta.taptoon.domain.image.dto;
+package com.sparta.taptoon.domain.image.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
 public record PreSignedUrlRequest(
         @NotBlank(message = "폴더 이름은 필수입니다.") @Pattern(regexp = "^[a-zA-Z0-9/._-]+$", message = "올바르지 않은 폴더 이름입니다.") String directory,
-        @NotBlank(message = "id 값은 필수입니다.") @Pattern(regexp = "^[a-zA-Z0-9/._-]+$", message = "올바르지 않은 폴더 이름입니다.") Long id,
+//        @NotNull(message = "id 값은 필수입니다.") @Pattern(regexp = "^[a-zA-Z0-9/._-]+$", message = "올바르지 않은 폴더 이름입니다.") Long id,
+        @NotNull(message = "id 값은 필수입니다.") Long id,
         @NotBlank(message = "파일 이름은 필수입니다.") @Pattern(regexp = "^[a-zA-Z0-9._-]+$", message = "올바르지 않은 파일 이름입니다.") String fileName) {
 }

--- a/src/main/java/com/sparta/taptoon/domain/image/dto/response/PresignedUrlResponse.java
+++ b/src/main/java/com/sparta/taptoon/domain/image/dto/response/PresignedUrlResponse.java
@@ -1,0 +1,8 @@
+package com.sparta.taptoon.domain.image.dto.response;
+
+public record PresignedUrlResponse(
+        String uploadingImageUrl,
+        Long imageEntityId
+) {
+
+}

--- a/src/main/java/com/sparta/taptoon/domain/image/service/ImageService.java
+++ b/src/main/java/com/sparta/taptoon/domain/image/service/ImageService.java
@@ -1,6 +1,8 @@
 package com.sparta.taptoon.domain.image.service;
 
+import com.sparta.taptoon.domain.image.dto.response.PresignedUrlResponse;
+
 public interface ImageService {
-    public String generatePresignedUrl(String folderPath, Long id, String fileName);
-    public String generatePresignedUrl(String folderPath, Long roomId, Long memberId, String fileName);
+    PresignedUrlResponse generatePresignedUrl(String folderPath, Long id, String fileName);
+    String generatePresignedUrl(String folderPath, Long roomId, Long memberId, String fileName);
 }

--- a/src/main/java/com/sparta/taptoon/domain/matchingpost/entity/MatchingPost.java
+++ b/src/main/java/com/sparta/taptoon/domain/matchingpost/entity/MatchingPost.java
@@ -2,6 +2,7 @@ package com.sparta.taptoon.domain.matchingpost.entity;
 
 import com.sparta.taptoon.domain.matchingpost.dto.request.UpdateMatchingPostRequest;
 import com.sparta.taptoon.domain.matchingpost.enums.ArtistType;
+import com.sparta.taptoon.domain.matchingpost.enums.Status;
 import com.sparta.taptoon.domain.matchingpost.enums.WorkType;
 import com.sparta.taptoon.domain.member.entity.Member;
 import com.sparta.taptoon.global.common.BaseEntity;
@@ -54,6 +55,10 @@ public class MatchingPost extends BaseEntity {
     @Column(name = "is_delete", nullable = false)
     private Boolean isDeleted;
 
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private Status status;
+
     @OneToMany(mappedBy = "matchingPost", cascade = CascadeType.ALL, orphanRemoval = true) // Elasticsearch 용도
     private List<MatchingPostImage> matchingPostImages = new ArrayList<>();
 
@@ -70,6 +75,7 @@ public class MatchingPost extends BaseEntity {
         this.description = description;
         this.viewCount = 0L;
         this.isDeleted = false;
+        this.status = Status.PENDING; // 처음에는 등록 대기 상태
     }
 
     // id 비교는 따로 쿼리가 안 날라감

--- a/src/main/java/com/sparta/taptoon/domain/matchingpost/entity/MatchingPostImage.java
+++ b/src/main/java/com/sparta/taptoon/domain/matchingpost/entity/MatchingPostImage.java
@@ -21,7 +21,7 @@ public class MatchingPostImage extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private MatchingPost matchingPost;
 
-    @Column(name = "image_url", nullable = false)
+    @Column(name = "image_url", nullable = false, length = 1000)
     private String imageUrl;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/sparta/taptoon/domain/matchingpost/enums/Status.java
+++ b/src/main/java/com/sparta/taptoon/domain/matchingpost/enums/Status.java
@@ -1,0 +1,9 @@
+package com.sparta.taptoon.domain.matchingpost.enums;
+
+/**
+ * 현재 `MatchingPost`가 활성화된 포스트인지 아닌지 구분할 때 사용됨. is_deleted랑 구분됨
+ * 이 컬럼은 한 번 `REDISTERED`로 바뀌면 다시 생성되지 않는 컬럼임. 그래서 좀 아쉽기는 하다.
+ */
+public enum Status {
+    PENDING, REGISTERED
+}

--- a/src/main/java/com/sparta/taptoon/domain/portfolio/entity/PortfolioImage.java
+++ b/src/main/java/com/sparta/taptoon/domain/portfolio/entity/PortfolioImage.java
@@ -18,7 +18,7 @@ public class PortfolioImage extends BaseEntity {
     @Column(name = "id", nullable = false, updatable = false)
     private Long id;
 
-    @Column(name = "image_url", nullable = false)
+    @Column(name = "image_url", nullable = false, length = 1000)
     private String imageUrl;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/test/java/com/sparta/taptoon/domain/images/uploadImageToS3.java
+++ b/src/test/java/com/sparta/taptoon/domain/images/uploadImageToS3.java
@@ -3,6 +3,7 @@ package com.sparta.taptoon.domain.images;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.sparta.taptoon.domain.image.S3UploadClient;
+import com.sparta.taptoon.domain.image.dto.response.PresignedUrlResponse;
 import com.sparta.taptoon.domain.image.service.ImageService;
 import com.sparta.taptoon.domain.image.service.ImageServiceImpl;
 import org.junit.jupiter.api.Test;
@@ -55,7 +56,7 @@ public class uploadImageToS3 {
                 .when(s3UploadClient)
                 .uploadFile(eq("image/jpeg"), any(byte[].class));
         //when
-        String preSignedUrl = imageService.generatePresignedUrl(directory,1L, fileName);
+        PresignedUrlResponse preSignedUrl = imageService.generatePresignedUrl(directory,1L, fileName);
 
         // 테스트 이미지 로드
         ClassPathResource resource = new ClassPathResource("test-images/test-image.jpg");
@@ -63,7 +64,7 @@ public class uploadImageToS3 {
 
         // 파일 업로드 - 예외가 발생하지 않으면 성공
         assertDoesNotThrow(() -> s3UploadClient.uploadFile("image/jpeg", imageBytes));
-        assertEquals(mockUrl.toString(), preSignedUrl);
+        assertEquals(mockUrl.toString(), preSignedUrl.uploadingImageUrl());
         verify(s3UploadClient).uploadFile(eq("image/jpeg"), any(byte[].class));
         verify(amazonS3).generatePresignedUrl(any(GeneratePresignedUrlRequest.class));
     }

--- a/src/test/java/com/sparta/taptoon/domain/images/uploadtoS3FromClient.java
+++ b/src/test/java/com/sparta/taptoon/domain/images/uploadtoS3FromClient.java
@@ -1,6 +1,7 @@
 package com.sparta.taptoon.domain.images;
 
 import com.sparta.taptoon.domain.image.S3UploadClient;
+import com.sparta.taptoon.domain.image.dto.response.PresignedUrlResponse;
 import com.sparta.taptoon.domain.image.service.ImageService;
 import feign.Client;
 import feign.Feign;
@@ -21,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 @SpringBootTest
 @ActiveProfiles("test")
-public class uploadtoS3FromClient {
+public class uploadToS3FromClient {
     @Autowired
     private ImageService imageService;
 
@@ -36,14 +37,14 @@ public class uploadtoS3FromClient {
         String directory = directory_t;
         String fileName = "test-image.jpg";
 
-        String presignedUrl = imageService.generatePresignedUrl(directory, 1L, fileName);
+        PresignedUrlResponse presignedUrlResponse = imageService.generatePresignedUrl(directory, 1L, fileName);
 
         S3UploadClient s3UploadClient = Feign.builder()
                 .contract(new SpringMvcContract())
                 .client(new Client.Default(null, null))
                 .encoder(new Encoder.Default())
                 .decoder(new Decoder.Default())
-                .target(S3UploadClient.class, presignedUrl);
+                .target(S3UploadClient.class, presignedUrlResponse.uploadingImageUrl());
 
         // 테스트 이미지 로드
         ClassPathResource resource = new ClassPathResource("test-images/test-image.jpg");


### PR DESCRIPTION
# 🚀  presignedUrl 반환 방식 변경; imageUrl -> (imageUrl + id)

## 💡 변경 사항
* PresignedUrl을 String으로만 반환하면 이미지 상태를 바꿔주는 데 제약이 있어 ImageEntity의 id 값도 같이 넘겨주는 방식으로 변경했습니다.

## 🚩 관련 이슈
* Closes #54 

## Reviewer
* [ ] 김창현
* [ ] 강성욱
* [x] 이진영
* [ ] 이상구

## ✅ 체크리스트
* [ ] 테스트 코드 작성 완료
* [ ] 문서 업데이트 확인
* [x] 코드 리뷰어 지정 완료

# 🔍 추가 설명
*